### PR TITLE
parse from string using regex

### DIFF
--- a/EmreBeratKR/IdleCash/Test/Scenes/Idle Cash Test Scene.unity
+++ b/EmreBeratKR/IdleCash/Test/Scenes/Idle Cash Test Scene.unity
@@ -179,6 +179,54 @@ MonoBehaviour:
   result:
     type: aa
     value: 250
+--- !u!1 &77540540
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 77540541}
+  - component: {fileID: 77540542}
+  m_Layer: 0
+  m_Name: '[Parse Test]'
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &77540541
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77540540}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1191041787}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &77540542
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 77540540}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 044b5472fb866454bad555d2d0cbf71b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  rawString: -3.14a
+  parsed:
+    type: a
+    value: -3.14
 --- !u!1 &105574462
 GameObject:
   m_ObjectHideFlags: 0
@@ -593,6 +641,7 @@ Transform:
   - {fileID: 921022155}
   - {fileID: 806875017}
   - {fileID: 35906238}
+  - {fileID: 77540541}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/EmreBeratKR/IdleCash/Test/Scripts/TestParse.cs
+++ b/EmreBeratKR/IdleCash/Test/Scripts/TestParse.cs
@@ -1,0 +1,19 @@
+using UnityEngine;
+using EmreBeratKR.IdleCash;
+
+namespace IdleCashSystem.Test
+{
+    public class TestParse : MonoBehaviour
+    {
+        public string rawString;
+        public IdleCash parsed;
+
+        private void OnValidate()
+        {
+            if (!string.IsNullOrEmpty(rawString))
+            {
+                parsed = IdleCash.Parse(rawString);
+            }
+        }
+    }
+}

--- a/EmreBeratKR/IdleCash/Test/Scripts/TestParse.cs.meta
+++ b/EmreBeratKR/IdleCash/Test/Scripts/TestParse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 044b5472fb866454bad555d2d0cbf71b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR add functionality to parse from string, using regex. (Kindly re-check from the Test scene)

example :
```c#
IdleCash cash = IdleCash.Parse("135a");   // similar to new IdleCash(135,"a");
IdleCash cashFail = IdleCash.Parse("random123"); // will fail, return IdleCash.Zero instead
// or using TryParse
IdleCash.TryParse("314a", out IdleCash cash2); // return true
IdleCash.TryParse("1a1a1", out IdleCash cash2); // return false
``` 